### PR TITLE
VS2022でのソース生成エラー対応のため、System.Memoryを4.5.5にダウングレード

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ using SimpleTextTemplate;
 using var bufferWriter = new ArrayPoolBufferWriter<byte>();
 var context = new SampleContext("Hello, World", 1000, new(2000, 1, 1, 0, 0, 0, TimeSpan.Zero));
 
-var writer = TemplateWriter.Create(_bufferWriter);
+var writer = TemplateWriter.Create(bufferWriter);
 TemplateRenderer.Render(ref writer, "{{ DateTimeOffsetValue:o }}_{{ StringValue }}!", in context);
 TemplateRenderer.Render(ref writer, "_{{ ConstantString }}_{{ ConstantInt:N3:ja-JP }}_{{ IntValue }}", in context, CultureInfo.InvariantCulture);
 writer.Flush();

--- a/Source/SimpleTextTemplate/SimpleTextTemplate.csproj
+++ b/Source/SimpleTextTemplate/SimpleTextTemplate.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Memory" Version="4.6.0" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0" />
   </ItemGroup>
 


### PR DESCRIPTION
fix #249 

.csprojに以下の設定を追加することで、`System.Memory`の`FileNotFoundException`は解消できるが今度は競合エラーが発生する。
そのため、一端の回避策として`System.Memory`をダウングレードする。

```csproj
<ItemGroup>
  <PackageReference Include="System.Memory" Version="4.6.0" GeneratePathProperty="true" PrivateAssets="all" />
</ItemGroup>

<PropertyGroup>
  <GetTargetPathDependsOn>$(GetTargetPathDependsOn);GetDependencyTargetPaths</GetTargetPathDependsOn>
</PropertyGroup>

<Target Name="GetDependencyTargetPaths">
  <ItemGroup>
    <TargetPathWithTargetPlatformMoniker Include="$(PKGSystem_Memory)\lib\netstandard2.0\System.Memory.dll" IncludeRuntimeDependency="false" />
  </ItemGroup>
</Target>
  ```